### PR TITLE
FIN-3416 granule utils internal usage preparations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "granule/util",
-    "description": "Granule Utilities",
+    "name": "dealroadshow/granule-util",
+    "description": "Granule Utilities fork",
     "keywords": ["enum", "tree", "array", "data", "collection", "map"],
     "type": "library",
     "require": {


### PR DESCRIPTION
ISSUES RESOLVED
------
https://finsight.myjetbrains.com/youtrack/issue/FIN-3416

DESCRIPTION
--
Providing the ability to internal require and use of forked package with new name [dealroadshow/granule-util](https://github.com/dealroadshow/util) instead of [granule/util](https://github.com/granulephp/util)

QA
--
WhiteList and BlackList add/edit functionality for Roadshow should work as usual.
There is also happened the replacement of some code libraries source from external to internal, while the code remains the same. Please keep in mind this fact just in case.
